### PR TITLE
refactor/ag/BaseMongooseRepository-to-use-specific-mongoose-Model-type

### DIFF
--- a/src/Shared/Repositories/BaseMongooseRepository.ts
+++ b/src/Shared/Repositories/BaseMongooseRepository.ts
@@ -5,14 +5,15 @@ import { NotFoundException } from '@nestjs/common';
 import IByOptions from './IByOptions';
 import { ICriteria } from '../Criteria/ICriteria';
 import { IPaginator } from '../Criteria/IPaginator';
+import { Model } from 'mongoose';
 
 abstract class BaseMongooseRepository<T extends IBaseDomain> implements IBaseRepository<T>
 {
     protected readonly entityName: string;
-    protected repository: any;
+    protected repository: Model<T>;
     protected populate: string[];
 
-    protected constructor(model: any, populate: string[] = [])
+    protected constructor(model: Model<T>, populate: string[] = [])
     {
         this.repository = model;
         this.populate = populate;


### PR DESCRIPTION
Updated the BaseMongooseRepository class to explicitly use the mongoose Model<T> type instead of a generic "any" type. This enhances type safety and clarity in the code, ensuring that the repository interacts properly with mongoose models.